### PR TITLE
Enforce role allowlist and refine console target resolution

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -4,6 +4,7 @@ local cfg  = Axiom.config or {}
 local hb   = tonumber(cfg.heartbeat_ms) or 60000
 local RES  = GetCurrentResourceName()
 local ax   = exports[RES]
+local CORE = 'Axiom-Core'
 local getTime = GetGameTimer
 local Wait = Wait
 
@@ -120,34 +121,73 @@ local function smokeAllowed(src)
   return ax:HasRole(uid,'admin') or false
 end
 
-local function resolveTargetUid(target)
-  if not target or target == '' then return nil, 'kein Ziel' end
+local function trim(s) return (s:gsub('^%s+', ''):gsub('%s+$', '')) end
+local function splitFirst(s, sep)
+  local a,b = s:find(sep, 1, true); if not a then return s, nil end
+  return s:sub(1, a-1), s:sub(b+1)
+end
+local function isUid(v) return type(v)=='string' and #v==10 and v:match('^[A-Za-z0-9]+$') end
+local function isHex(v) return type(v)=='string' and v:match('^[0-9a-fA-F]+$') end
 
-  -- UID with optional prefix or bare 10 alnum
-  local u = target:match('^uid:([A-Za-z0-9]+)$')
-            or target:match('^([A-Za-z0-9]{10})$')
-  if u then return u end
+local function resolveUid(target)
+  target = trim(target or '')
+  if target == '' then return nil, 'invalid target: empty' end
 
-  -- License hash with optional prefix or bare 32-64 hex
-  local lic = target:match('^license:([0-9A-Fa-f]+)$')
-              or target:match('^([0-9A-Fa-f]{32,64})$')
-  if lic then
-    local uid = ensureUidFor('license', lic:lower(), '')
-    if uid then return uid end
-    return nil, 'Lizenz nicht gefunden'
+  -- bare UID
+  if isUid(target) then return target end
+
+  -- bare Server-ID
+  if target:match('^%d+$') then
+    local sid = tonumber(target)
+    if sid and sid >= 1 and sid <= 4096 then
+      local uid = exports[CORE]:GetUid(sid)
+      if not uid then return nil, ('no uid for server id %d (offline?)'):format(sid) end
+      return uid
+    end
   end
 
-  -- Numeric server ID with optional prefix or bare digits
-  local sid = target:match('^id:(%d+)$')
-              or target:match('^(%d+)$')
-  if sid then
-    local srcId = tonumber(sid)
-    local uid = ax:GetUid(srcId)
-    if not uid then return nil, 'Spieler nicht online' end
+  -- bare license (hex 32–64)
+  if #target >= 32 and #target <= 64 and isHex(target) then
+    local row = exports[CORE]:DbSingle(
+      'SELECT uid FROM ax_players WHERE id_kind=? AND id_value=? LIMIT 1',
+      { 'license', target:lower() }
+    )
+    if not row or not row.uid then
+      return nil, ('no player found for license:%s'):format(target)
+    end
+    return row.uid
+  end
+
+  -- prefixierte Formen
+  local kind, value = splitFirst(target, ':')
+  if not value then return nil, 'invalid target format' end
+  if value:find(':', 1, true) then
+    local k2, v2 = splitFirst(value, ':'); if k2 == kind then value = v2 end
+  end
+
+  kind = kind:lower()
+  if kind == 'uid' then
+    if not isUid(value) then return nil, 'invalid uid' end
+    return value
+  elseif kind == 'id' then
+    if not value:match('^%d+$') then return nil, 'invalid server id' end
+    local sid = tonumber(value)
+    local uid = exports[CORE]:GetUid(sid)
+    if not uid then return nil, ('no uid for server id %d (offline?)'):format(sid) end
     return uid
+  else
+    local allowed = { license=true, steam=true, rockstar=true, fivem=true, discord=true, xbl=true, live=true }
+    if not allowed[kind] then return nil, 'unknown identifier kind' end
+    if value == '' then return nil, 'missing identifier value' end
+    local row = exports[CORE]:DbSingle(
+      'SELECT uid FROM ax_players WHERE id_kind=? AND id_value=? LIMIT 1',
+      { kind, value }
+    )
+    if not row or not row.uid then
+      return nil, ('no player found for %s:%s'):format(kind, value)
+    end
+    return row.uid
   end
-
-  return nil, 'Ungültiges Ziel'
 end
 
 -- Commands
@@ -228,37 +268,44 @@ end,false)
 RegisterCommand('axiom:roles:add', function(src, args)
   if src~=0 then print('Nur Server-Konsole.') return end
   local target, role = args[1], args[2]
-  if not target or not role then print('Usage: axiom:roles:add <target> <role>') return end
-  local uid, err = resolveTargetUid(target)
-  if not uid then print('Fehler: '..(err or 'UID nicht gefunden')) return end
-  if ax:HasRole(uid, role) then print('Rolle existiert bereits') return end
-  ax:AddRole(uid, role)
+  if not target or not role then print('Usage: axiom:roles:add <uid|id|license|...> <role>') return end
+  local uid, err = resolveUid(target)
+  if not uid then print(('[Axiom] error: %s'):format(err or 'invalid target')) return end
+  local ok, rerr = ax:AddRole(uid, role)
+  if not ok then
+    if rerr == 'E_ROLE_UNKNOWN' then
+      local allowed = table.concat(((cfg.roles or {}).allow or {}), ', ')
+      print(('[Axiom] Rolle unbekannt. Erlaubt: %s'):format(allowed))
+    else
+      print('Fehler: '..tostring(rerr))
+    end
+    return
+  end
   log.info('[SECURITY] Role %s %s -> %s', 'add', role, uid)
-  print(('[Axiom] Rolle %s für %s hinzugefügt'):format(role, uid))
+  print(('[Axiom] added role %s for %s'):format(role, uid))
 end,false)
 
 RegisterCommand('axiom:roles:remove', function(src, args)
   if src~=0 then print('Nur Server-Konsole.') return end
   local target, role = args[1], args[2]
-  if not target or not role then print('Usage: axiom:roles:remove <target> <role>') return end
-  local uid, err = resolveTargetUid(target)
-  if not uid then print('Fehler: '..(err or 'UID nicht gefunden')) return end
-  if not ax:HasRole(uid, role) then print('Rolle nicht vorhanden') return end
+  if not target or not role then print('Usage: axiom:roles:remove <uid|id|license|...> <role>') return end
+  local uid, err = resolveUid(target)
+  if not uid then print(('[Axiom] error: %s'):format(err or 'invalid target')) return end
   ax:RemoveRole(uid, role)
   log.info('[SECURITY] Role %s %s -> %s', 'remove', role, uid)
-  print(('[Axiom] Rolle %s für %s entfernt'):format(role, uid))
+  print(('[Axiom] removed role %s for %s'):format(role, uid))
 end,false)
 
 RegisterCommand('axiom:roles:list', function(src, args)
   if src~=0 then print('Nur Server-Konsole.') return end
   local target = args[1]
-  if not target then print('Usage: axiom:roles:list <target>') return end
-  local uid, err = resolveTargetUid(target)
-  if not uid then print('Fehler: '..(err or 'UID nicht gefunden')) return end
-  local roles = ax:GetRoles(uid) or {}
-  if #roles==0 then
-    print(('[Axiom] %s hat keine Rollen'):format(uid))
+  if not target then print('Usage: axiom:roles:list <uid|id|license|...>') return end
+  local uid, err = resolveUid(target)
+  if not uid then print(('[Axiom] error: %s'):format(err or 'invalid target')) return end
+  local roles = ax:ListRoles(uid) or {}
+  if #roles == 0 then
+    print(('[Axiom] no roles for %s'):format(uid))
   else
-    print(('[Axiom] Rollen für %s: %s'):format(uid, table.concat(roles, ', ')))
+    print(('[Axiom] roles for %s: %s'):format(uid, table.concat(roles, ', ')))
   end
 end,false)

--- a/server/services/players_svc.lua
+++ b/server/services/players_svc.lua
@@ -2,6 +2,7 @@ Axiom = Axiom or {}
 local RES = GetCurrentResourceName()
 local ax  = exports[RES]
 local cfg = Axiom.config or {}
+local log = Axiom.log
 
 local PREFIX = {
   license='license:', rockstar='license:',
@@ -35,41 +36,58 @@ AddEventHandler('playerJoining', function()
 end)
 AddEventHandler('playerDropped', function() local src=source; local uid=uidBySrc[src]; uidBySrc[src]=nil; if uid then srcByUid[uid]=nil end end)
 
--- Rollen (ax_players.roles JSON)
-local function fetchRoles(uid)
-  local row = ax:DbSingle('SELECT roles FROM ax_players WHERE uid=? LIMIT 1', { uid }) or {}
-  local raw = row.roles
-  if not raw or raw=='' then return {} end
-  local ok, list = pcall(json.decode, raw)
-  return (ok and type(list)=='table') and list or {}
-end
-
-local function saveRoles(uid, roles)
-  ax:DbExec('UPDATE ax_players SET roles=? WHERE uid=?', { json.encode(roles), uid })
-end
-
+-- Rollen in separater Tabelle (ax_perm_roles)
 local function hasRole(uid, role)
-  local roles = fetchRoles(uid)
-  for _,r in ipairs(roles) do if r==role then return true end end
-  return false
+  local r = ax:DbScalar(
+    'SELECT 1 FROM ax_perm_roles WHERE uid = ? AND role = ? LIMIT 1',
+    { uid, role }
+  )
+  return r ~= nil
+end
+
+local roleAllow = {}
+do
+  local arr = ((cfg.roles or {}).allow) or {}
+  for _, r in ipairs(arr) do roleAllow[r] = true end
+end
+
+local function roleAllowed(role)
+  return roleAllow[role] or false
 end
 
 local function addRole(uid, role)
-  local roles = fetchRoles(uid)
-  for _,r in ipairs(roles) do if r==role then return end end
-  roles[#roles+1] = role
-  saveRoles(uid, roles)
-  if Axiom.audit then Axiom.audit('role.add','uid=%s role=%s',uid,role) end
+  if not roleAllowed(role) then
+    if log and log.warn then log.warn('addRole: unknown role %s', tostring(role)) end
+    return false, 'E_ROLE_UNKNOWN'
+  end
+  ax:DbExec(
+    'INSERT IGNORE INTO ax_perm_roles (uid, role) VALUES (?, ?)',
+    { uid, role }
+  )
+  if Axiom.audit then Axiom.audit('role.add', 'uid=%s role=%s', uid, role) end
+  return true
 end
 
 local function removeRole(uid, role)
-  local roles = fetchRoles(uid)
-  local idx
-  for i,r in ipairs(roles) do if r==role then idx=i break end end
-  if not idx then return end
-  table.remove(roles, idx)
-  saveRoles(uid, roles)
-  if Axiom.audit then Axiom.audit('role.remove','uid=%s role=%s',uid,role) end
+  ax:DbExec(
+    'DELETE FROM ax_perm_roles WHERE uid = ? AND role = ?',
+    { uid, role }
+  )
+  if Axiom.audit then Axiom.audit('role.remove', 'uid=%s role=%s', uid, role) end
+end
+
+local function listRoles(uid)
+  local rows = ax:DbQuery(
+    'SELECT role FROM ax_perm_roles WHERE uid = ? ORDER BY role ASC',
+    { uid }
+  ) or {}
+  local out = {}
+  for _, r in ipairs(rows) do out[#out+1] = r.role end
+  return out
+end
+
+local function isAdmin(uid)
+  return hasRole(uid, 'admin')
 end
 
 -- Player-Meta KV
@@ -84,10 +102,12 @@ exports('GetSrc', function(uid) return srcByUid[uid] end)
 exports('ForEachPlayer', function(cb) for s,u in pairs(uidBySrc) do if cb(s,u)==false then break end end end)
 exports('Count', function() local c=0 for _ in pairs(uidBySrc) do c=c+1 end return c end)
 
-exports('HasRole',   function(uid, role) return hasRole(uid, role) end)
-exports('AddRole',   function(uid, role) addRole(uid, role) end)
-exports('RemoveRole',function(uid, role) removeRole(uid, role) end)
-exports('GetRoles',  function(uid) return fetchRoles(uid) end)
+exports('HasRole',     hasRole)
+exports('AddRole',     addRole)
+exports('RemoveRole',  removeRole)
+exports('ListRoles',   listRoles)
+exports('RoleAllowed', roleAllowed)
+exports('IsAdmin',     isAdmin)
 
 exports('PlayerGetMeta',   playerGetMeta)
 exports('PlayerSetMetaKV', playerSetMetaKV)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -17,6 +17,10 @@ Axiom.config = {
     allow_uids = {},
   },
 
+  roles = {
+    allow = { 'admin', 'dev', 'staff' },
+  },
+
   -- Rate-Limiter
   rate_limit = {
     capacity   = 5,


### PR DESCRIPTION
## Summary
- Restrict role assignment to allow-listed values and manage roles solely in `ax_perm_roles`
- Add exports for role helpers and admin checks
- Harden console role commands and add robust target UID resolution

## Testing
- `mysql -e "DESCRIBE ax_perm_roles;"` *(fails: command not found)*
- `luacheck server/services/players_svc.lua server/main.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d3bd8c168832f8a1acda616ccdd12