### PR TITLE
feat(core): add error objects, caching and metrics

### DIFF
--- a/server/core/cache.lua
+++ b/server/core/cache.lua
@@ -1,0 +1,73 @@
+Axiom = Axiom or {}
+local cfg = (Axiom.config and Axiom.config.cache) or {}
+local ttl = tonumber(cfg.ttl_sec) or 60
+
+local store = {}
+local metrics = { hits = 0, misses = 0, evictions = 0 }
+
+local function now()
+  return os.time()
+end
+
+local function size()
+  local c = 0
+  for _ in pairs(store) do c = c + 1 end
+  return c
+end
+
+local function get(key)
+  local e = store[key]
+  if e then
+    if e.exp > now() then
+      metrics.hits = metrics.hits + 1
+      return e.val
+    else
+      store[key] = nil
+      metrics.evictions = metrics.evictions + 1
+    end
+  end
+  metrics.misses = metrics.misses + 1
+  return nil
+end
+
+local function set(key, val, t)
+  store[key] = { val = val, exp = now() + (t or ttl) }
+end
+
+local function del(key)
+  if store[key] then
+    store[key] = nil
+    metrics.evictions = metrics.evictions + 1
+  end
+end
+
+local function bust()
+  store = {}
+end
+
+local function metricsCopy()
+  return { hits = metrics.hits, misses = metrics.misses, size = size(), evictions = metrics.evictions }
+end
+
+Axiom.cache = {
+  get = get,
+  set = set,
+  del = del,
+  metrics = metricsCopy,
+  bust = bust,
+}
+
+exports('CacheGet', function(key) return get(key) end)
+exports('CacheSet', function(key, val, t) set(key, val, t) end)
+exports('CacheDel', function(key) del(key) end)
+exports('CacheMetrics', function() return metricsCopy() end)
+exports('CacheBust', function() bust() end)
+
+AddEventHandler('onResourceStart', function(res)
+  if res ~= GetCurrentResourceName() then return end
+  bust()
+end)
+AddEventHandler('onResourceStop', function(res)
+  if res ~= GetCurrentResourceName() then return end
+  bust()
+end)

--- a/server/core/db.lua
+++ b/server/core/db.lua
@@ -1,5 +1,47 @@
 Axiom = Axiom or {}
 local log = Axiom.log or { warn=print, error=print, info=print }
+local cfg = (Axiom.config and Axiom.config.db) or {}
+local slow_ms = tonumber(cfg.slow_ms) or 100
+
+local stats = { calls = 0, total_ms = 0, slow = 0, samples = {}, top = {} }
+local SAMPLE_MAX = 200
+
+local function fingerprint(sql)
+  sql = (sql or ''):gsub('%s+',' ')
+  if #sql > 120 then sql = sql:sub(1,120)..'…' end
+  return sql
+end
+
+local function record(op, sql, ms)
+  stats.calls = stats.calls + 1
+  stats.total_ms = stats.total_ms + ms
+  stats.samples[#stats.samples+1] = ms
+  if #stats.samples > SAMPLE_MAX then table.remove(stats.samples,1) end
+  local fp = fingerprint(sql)
+  local t = stats.top[fp] or { count = 0, total = 0 }
+  t.count = t.count + 1
+  t.total = t.total + ms
+  stats.top[fp] = t
+  if ms >= slow_ms then
+    stats.slow = stats.slow + 1
+    log.warn('[DB][slow] %dms %s %s', ms, op, fp)
+  end
+end
+
+local function metrics()
+  local avg = (stats.calls > 0) and (stats.total_ms / stats.calls) or 0
+  local samples = { table.unpack(stats.samples) }
+  table.sort(samples)
+  local p95 = 0
+  if #samples > 0 then
+    local idx = math.ceil(#samples * 0.95)
+    p95 = samples[idx]
+  end
+  local top = {}
+  for k,v in pairs(stats.top) do top[#top+1] = { fingerprint=k, count=v.count, avg_ms=(v.total/v.count) } end
+  table.sort(top, function(a,b) return a.count>b.count end)
+  return { calls=stats.calls, slow_warnings=stats.slow, avg_ms=avg, p95_ms=p95, top_queries=top }
+end
 
 local function ready()
   return type(MySQL) == 'table'
@@ -13,13 +55,38 @@ local function need()
   return true
 end
 
-local function scalar(q, p) if not need() then return nil end return MySQL.scalar.await(q, p or {}) end
-local function single(q, p) if not need() then return nil end return MySQL.single.await(q, p or {}) end
-local function query(q, p)  if not need() then return nil end return MySQL.query.await(q, p or {}) end
-local function exec(q, p)   if not need() then return 0   end return MySQL.update.await(q, p or {}) end
+local function scalar(q, p)
+  if not need() then return nil end
+  local t0 = GetGameTimer()
+  local res = MySQL.scalar.await(q, p or {})
+  record('scalar', q, GetGameTimer() - t0)
+  return res
+end
+local function single(q, p)
+  if not need() then return nil end
+  local t0 = GetGameTimer()
+  local res = MySQL.single.await(q, p or {})
+  record('single', q, GetGameTimer() - t0)
+  return res
+end
+local function query(q, p)
+  if not need() then return nil end
+  local t0 = GetGameTimer()
+  local res = MySQL.query.await(q, p or {})
+  record('query', q, GetGameTimer() - t0)
+  return res
+end
+local function exec(q, p)
+  if not need() then return 0 end
+  local t0 = GetGameTimer()
+  local res = MySQL.update.await(q, p or {})
+  record('exec', q, GetGameTimer() - t0)
+  return res
+end
 
 local function tx(fn)
   if not need() then return false, 'no_db' end
+  local t0 = GetGameTimer()
   MySQL.update.await('START TRANSACTION')
   local ok, err = pcall(function()
     local sql = {
@@ -30,8 +97,8 @@ local function tx(fn)
     }
     return fn(sql)
   end)
-  if not ok then MySQL.update.await('ROLLBACK'); return false, tostring(err) end
-  MySQL.update.await('COMMIT'); return true
+  if not ok then MySQL.update.await('ROLLBACK'); record('tx', 'tx', GetGameTimer()-t0); return false, tostring(err) end
+  MySQL.update.await('COMMIT'); record('tx', 'tx', GetGameTimer()-t0); return true
 end
 
 exports('DbScalar', scalar)
@@ -39,6 +106,8 @@ exports('DbSingle', single)
 exports('DbQuery',  query)
 exports('DbExec',   exec)
 exports('DbTx',     tx)
+
+exports('DbMetrics', function() return metrics() end)
 
 local function health()
   if not need() then return false end

--- a/server/core/errors.lua
+++ b/server/core/errors.lua
@@ -5,16 +5,18 @@ Axiom.err = Axiom.err or {}
 local MAX = 50
 local ring = {}
 local head, size = 0, 0
+local counts = {}
 
-local function push(scope, code, message, details)
+local function push(scope, code, msg, data)
   head = (head % MAX) + 1
   ring[head] = {
     ts = os.time(),
     scope = scope or 'core',
     code = code or 'error',
-    message = message or '',
-    details = details,
+    msg = msg or '',
+    data = data,
   }
+  counts[code or 'error'] = (counts[code or 'error'] or 0) + 1
   if size < MAX then size = size + 1 end
 end
 
@@ -28,13 +30,20 @@ local function list(n)
   return out
 end
 
-function Axiom.err.ok(data)  return { ok = true,  data = data } end
-function Axiom.err.fail(code, message, details)
-  push('rpc', code, message, details)
-  return { ok = false, code = code or 'error', message = message or '', details = details }
+local function countsCopy()
+  local out = {}
+  for k,v in pairs(counts) do out[k]=v end
+  return out
 end
 
-exports('ErrOk',   function(data)                        return Axiom.err.ok(data) end)
-exports('ErrFail', function(code, msg, details)          return Axiom.err.fail(code, msg, details) end)
-exports('ErrPush', function(scope, code, msg, details)   push(scope, code, msg, details) end)
-exports('ErrList', function(n)                           return list(n) end)
+function Axiom.err.ok(data)  return { ok = true, code = nil, data = data } end
+function Axiom.err.fail(code, msg, data)
+  push('core', code, msg, data)
+  return { ok = false, code = code or 'E_UNKNOWN', msg = msg or '', data = data }
+end
+
+exports('ErrOk',     function(data)                      return Axiom.err.ok(data) end)
+exports('ErrFail',   function(code, msg, data)           return Axiom.err.fail(code, msg, data) end)
+exports('ErrPush',   function(scope, code, msg, data)    push(scope, code, msg, data) end)
+exports('ErrList',   function(n)                         return list(n) end)
+exports('ErrCounts', function()                          return countsCopy() end)

--- a/server/core/ratelimit.lua
+++ b/server/core/ratelimit.lua
@@ -16,8 +16,10 @@ local function allow(key)
   if not b then b = { tokens = cap, last = t, cap = cap, refill = refill }; buckets[key] = b
   else if b.cap ~= cap or b.refill ~= refill then b.tokens = math.min(cap, b.tokens); b.cap, b.refill = cap, refill end end
   local dt = t - b.last; if dt > 0 then local add = (dt / b.refill) * b.cap; if add > 0 then b.tokens = math.min(b.cap, b.tokens + add); b.last = t end end
-  if b.tokens >= 1 then b.tokens = b.tokens - 1; return true end
-  return false
+  if b.tokens >= 1 then b.tokens = b.tokens - 1; return true, 0 end
+  local need = 1 - b.tokens
+  local ms = math.ceil((need / b.cap) * b.refill)
+  return false, ms
 end
 function Axiom.RateLimit(key, src) key = tostring(key)..':'..tostring(src or 0); return allow(key) end
 exports('RateLimit', function(key, src) return Axiom.RateLimit(key, src) end)

--- a/server/core/validator.lua
+++ b/server/core/validator.lua
@@ -1,5 +1,6 @@
 Axiom = Axiom or {}
 Axiom.v = {}
+local err = (Axiom.err and Axiom.err.fail) or function(code,msg,data) return { ok=false, code=code, msg=msg, data=data } end
 
 function Axiom.v.type(val, want) return (type(val) == want), ('expected '..want..', got '..type(val)) end
 function Axiom.v.len(s, min, max) if type(s)~='string' then return false,'expected string' end local n=#s; if min and n<min then return false,'min '..min end if max and n>max then return false,'max '..max end return true end
@@ -8,8 +9,8 @@ function Axiom.v.enum(val, list) for _,v in ipairs(list or {}) do if v==val then
 
 function Axiom.v.check(payload, spec)
   for _,rule in ipairs(spec or {}) do
-    local ok, err = rule.check(payload[rule.key])
-    if not ok then return false, { key = rule.key, reason = err or 'invalid' } end
+    local ok, e = rule.check(payload[rule.key])
+    if not ok then return false, err('E_INVALID', e or 'invalid', { key = rule.key }) end
   end
   return true
 end

--- a/server/services/players_svc.lua
+++ b/server/services/players_svc.lua
@@ -3,6 +3,8 @@ local log = Axiom.log or { info=print, warn=print, error=print }
 local RES = GetCurrentResourceName()
 local ax  = exports[RES]
 local cfg = Axiom.config or {}
+local cache = Axiom.cache or {}
+local err = Axiom.err or { ok=function(d) return {ok=true,code=nil,data=d} end, fail=function(c,m,d) return {ok=false,code=c,msg=m,data=d} end }
 local allowedRoles = (cfg.roles and cfg.roles.allow) or {}
 
 local function roleAllowed(role)
@@ -27,26 +29,45 @@ local function pickIdentifier(src)
     if id then for kind,pfx in pairs(PREFIX) do if id:sub(1,#pfx)==pfx then found[kind]=id end end end
   end
   for _,kind in ipairs(preferred) do
-    local id = found[kind]; if id then return kind, id:sub(#(PREFIX[kind])+1) end
+    local id = found[kind]
+    if id then
+      local val = id:sub(#(PREFIX[kind])+1)
+      if cache.set then cache.set(('ident:%s:%s'):format(src, kind), val) end
+      return kind, val
+    end
   end
-  for kind,id in pairs(found) do return kind, id:sub(#(PREFIX[kind])+1) end
+  for kind,id in pairs(found) do
+    local val = id:sub(#(PREFIX[kind])+1)
+    if cache.set then cache.set(('ident:%s:%s'):format(src, kind), val) end
+    return kind, val
+  end
   return nil
 end
 
 -- uid<->src Map
 local uidBySrc, srcByUid = {}, {}
-local function setMap(src, uid) uidBySrc[src]=uid; if uid then srcByUid[uid]=src end end
+local function setMap(src, uid)
+  uidBySrc[src]=uid; if uid then srcByUid[uid]=src end
+  if cache.set then cache.set('uid:'..tostring(src), uid) end
+end
 
 AddEventHandler('playerJoining', function()
   local src=source; local kind,val=pickIdentifier(src); if not kind then return end
   local row = ax:DbSingle('SELECT uid FROM ax_players WHERE id_kind=? AND id_value=? LIMIT 1', { kind, val })
   setMap(src, row and row.uid or nil)
 end)
-AddEventHandler('playerDropped', function() local src=source; local uid=uidBySrc[src]; uidBySrc[src]=nil; if uid then srcByUid[uid]=nil end end)
+AddEventHandler('playerDropped', function()
+  local src=source; local uid=uidBySrc[src]; uidBySrc[src]=nil; if uid then srcByUid[uid]=nil end
+  if cache.del then
+    cache.del('uid:'..tostring(src))
+    for kind,_ in pairs(PREFIX) do cache.del(('ident:%s:%s'):format(src, kind)) end
+  end
+end)
 
 AddEventHandler('onResourceStart', function(res)
   if res ~= RES then return end
   uidBySrc, srcByUid = {}, {}
+  if cache.bust then cache.bust() end
   for _, sid in ipairs(GetPlayers()) do
     local src = tonumber(sid)
     local kind, val = pickIdentifier(src)
@@ -65,27 +86,51 @@ end)
 AddEventHandler('onResourceStop', function(res)
   if res ~= RES then return end
   uidBySrc, srcByUid = {}, {}
+  if cache.bust then cache.bust() end
 end)
 
--- Rollen in separater Tabelle (ax_perm_roles)
+-- Rollen in separater Tabelle (ax_perm_roles) mit Cache
+local function listRoles(uid)
+  local key = 'roles:'..tostring(uid)
+  local cached = cache.get and cache.get(key)
+  if cached then return cached end
+  local rows = ax:DbQuery(
+    'SELECT role FROM ax_perm_roles WHERE uid = ? ORDER BY role ASC',
+    { uid }
+  ) or {}
+  local out = {}
+  for _, r in ipairs(rows) do out[#out+1] = r.role end
+  if cache.set then
+    cache.set(key, out)
+    for _,r in ipairs(out) do cache.set(('role:%s:%s'):format(uid, r), true) end
+  end
+  return out
+end
+
 local function hasRole(uid, role)
-  local r = ax:DbScalar(
-    'SELECT 1 FROM ax_perm_roles WHERE uid = ? AND role = ? LIMIT 1',
-    { uid, role }
-  )
-  return r ~= nil
+  local key = ('role:%s:%s'):format(uid, role)
+  local hit = cache.get and cache.get(key)
+  if hit ~= nil then return hit end
+  local roles = listRoles(uid)
+  for _,r in ipairs(roles) do if r == role then if cache.set then cache.set(key, true) end; return true end end
+  if cache.set then cache.set(key, false) end
+  return false
 end
 
 local function addRole(uid, role)
   if not roleAllowed(role) then
     log.warn('Unknown role %s', tostring(role))
-    return false, 'E_ROLE_UNKNOWN'
+    return err.fail('E_INVALID', 'role_unknown')
   end
   ax:DbExec(
     'INSERT IGNORE INTO ax_perm_roles (uid, role) VALUES (?, ?)',
     { uid, role }
   )
-  return true
+  if cache.del then
+    cache.del(('roles:%s'):format(uid))
+    cache.del(('role:%s:%s'):format(uid, role))
+  end
+  return err.ok()
 end
 
 local function removeRole(uid, role)
@@ -93,17 +138,11 @@ local function removeRole(uid, role)
     'DELETE FROM ax_perm_roles WHERE uid = ? AND role = ?',
     { uid, role }
   )
-  return true
-end
-
-local function listRoles(uid)
-  local rows = ax:DbQuery(
-    'SELECT role FROM ax_perm_roles WHERE uid = ? ORDER BY role ASC',
-    { uid }
-  ) or {}
-  local out = {}
-  for _, r in ipairs(rows) do out[#out+1] = r.role end
-  return out
+  if cache.del then
+    cache.del(('roles:%s'):format(uid))
+    cache.del(('role:%s:%s'):format(uid, role))
+  end
+  return err.ok()
 end
 
 -- Player-Meta KV
@@ -113,7 +152,14 @@ local function playerDelMetaKV(uid,k) ax:DbExec('DELETE FROM ax_player_meta WHER
 
 -- Exports
 exports('GetIdent', function(src) return pickIdentifier(src) end)
-exports('GetUid', function(src) local uid=uidBySrc[src]; if uid then return uid end local kind,val=pickIdentifier(src); if not kind then return nil end local row=ax:DbSingle('SELECT uid FROM ax_players WHERE id_kind=? AND id_value=? LIMIT 1',{kind,val}); uid=row and row.uid or nil; setMap(src,uid); return uid end)
+exports('GetUid', function(src)
+  local uid = uidBySrc[src]
+  if not uid and cache.get then uid = cache.get('uid:'..tostring(src)) end
+  if uid then return uid end
+  local kind,val=pickIdentifier(src); if not kind then return nil end
+  local row=ax:DbSingle('SELECT uid FROM ax_players WHERE id_kind=? AND id_value=? LIMIT 1',{kind,val}); uid=row and row.uid or nil;
+  setMap(src,uid); return uid
+end)
 exports('GetSrc', function(uid) return srcByUid[uid] end)
 exports('ForEachPlayer', function(cb) for s,u in pairs(uidBySrc) do if cb(s,u)==false then break end end end)
 exports('Count', function() local c=0 for _ in pairs(uidBySrc) do c=c+1 end return c end)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -26,6 +26,10 @@ Axiom.config = {
     },
   },
 
+  db = { slow_ms = 100 },
+
+  cache = { ttl_sec = 60 },
+
   health = { errors_last_n = 5, top_rpc_n = 5 },
 
   roles = {


### PR DESCRIPTION
## Summary
- unify error handling via {ok, code, msg, data}
- add in-memory cache for uid/role lookups
- track DB slow queries and expose raw metrics

## Testing
- `lua -v` *(fails: command not found)*
- `luac -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d57d44c54832f9ea69bce790dcf5d