### PR TITLE
Harden migration runner and database error logging

### DIFF
--- a/server/core/migrations.lua
+++ b/server/core/migrations.lua
@@ -32,6 +32,12 @@ local function RegisterMigration(module, version, sql)
   table.sort(regs[module], function(a,b) return tostring(a.version) < tostring(b.version) end)
 end
 
+local function preview(sql)
+  sql = (sql or ''):gsub('%s+',' ')
+  if #sql > 120 then sql = sql:sub(1,120)..'…' end
+  return sql
+end
+
 local function runFor(mod)
   local list = regs[mod]; if not list or #list==0 then return end
   for _,m in ipairs(list) do
@@ -40,15 +46,47 @@ local function runFor(mod)
       if Axiom.audit then Axiom.audit('migration.start', mod..':'..m.version, 'system') end
       local ok, err = pcall(function()
         if type(m.sql) == 'function' then
-          return m.sql()
+          local function helper(stage, fn)
+            return function(sql, params)
+              assert(type(sql)=='string', ('E_DB_BADSQL: expected string, got %s'):format(type(sql)))
+              if params ~= nil and type(params) ~= 'table' then error(('E_DB_BADPARAMS: expected table, got %s'):format(type(params))) end
+              local ok2, res2 = pcall(fn, sql, params)
+              if not ok2 then error({ stage=stage, sql=sql, params_kind=type(params), err=tostring(res2) }) end
+              return res2
+            end
+          end
+          local ctx = {}
+          ctx.scalar = helper('scalar', DbScalar)
+          ctx.exec   = helper('exec',   DbExec)
+          ctx.tx     = function(fn)
+            assert(type(fn)=='function', ('E_DB_BADTXFN: expected function, got %s'):format(type(fn)))
+            return ax:DbTx(function(tx)
+              local txCtx = {
+                scalar = helper('tx.scalar', tx.scalar),
+                exec   = helper('tx.exec',   tx.exec),
+              }
+              return fn(txCtx)
+            end)
+          end
+          return m.sql(ctx)
         else
+          assert(type(m.sql)=='string', ('E_DB_BADSQL: expected string, got %s'):format(type(m.sql)))
           return DbExec(m.sql)
         end
       end)
       if not ok then
-        local msg = err
-        if type(err) == 'table' then msg = err.message or err.code or tostring(err) end
-        log.error('Migration %s:%s FEHLER: %s', mod, m.version, tostring(msg))
+        local det = err
+        local msg, stage, sqlPrev, paramsKind
+        if type(det) == 'table' then
+          msg        = det.err or det.message or det.code or tostring(det)
+          stage      = det.stage
+          sqlPrev    = preview(det.sql)
+          paramsKind = det.params_kind
+        else
+          msg = tostring(det)
+        end
+        log.error('Migration %s:%s FEHLER stage=%s sql="%s" params=%s error=%s\n%s',
+          mod, m.version, tostring(stage or '?'), tostring(sqlPrev or ''), tostring(paramsKind or 'nil'), tostring(msg), debug.traceback())
         if Axiom.audit then Axiom.audit('migration.error', mod..':'..m.version, 'system', tostring(msg)) end
         return
       end

--- a/server/core/migrations_core.lua
+++ b/server/core/migrations_core.lua
@@ -71,7 +71,7 @@ RegisterMigration('axiom-core', '0013_character_meta', [[
 ]])
 
 -- 0014: Indexpflege
-RegisterMigration('axiom-core', '0014_indexes', function()
+RegisterMigration('axiom-core', '0014_indexes', function(ctx)
   local log = Axiom.log or { info=print }
   local indexes = {
     { table='ax_perm_roles',    index='ix_uid', column='uid'  },
@@ -79,16 +79,18 @@ RegisterMigration('axiom-core', '0014_indexes', function()
     { table='ax_player_meta',   index='ix_uid', column='uid'  },
     { table='ax_character_meta',index='ix_cid', column='cid'  },
   }
-  local ok, err = DbTx(function(sql)
+  ctx.tx(function(tx)
     for _, ix in ipairs(indexes) do
-      local exists = sql.scalar([[SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?]], {ix.table, ix.index}) or 0
+      local exists = tx.scalar(
+        [[SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?]],
+        {ix.table, ix.index}
+      ) or 0
       if exists == 0 then
-        sql.exec(('ALTER TABLE %s ADD INDEX %s (%s)'):format(ix.table, ix.index, ix.column))
+        tx.exec(('ALTER TABLE %s ADD INDEX %s (%s)'):format(ix.table, ix.index, ix.column))
         log.info('Migration 0014: created index %s on %s(%s)', ix.index, ix.table, ix.column)
       else
         log.info('Migration 0014: index %s already present', ix.index)
       end
     end
   end)
-  if not ok then error({ code = 'E_DB', message = err }) end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -16,7 +16,8 @@ local running = true
 CreateThread(function()
   log.info('Core %s gestartet (Resource: %s) – LogLevel=%s, Heartbeat=%dms',
     Axiom.version, RES, (cfg.log_level or 'info'), hb)
-  pcall(function() ax:RunMigrations('axiom-core') end)
+  local ok, err = pcall(function() ax:RunMigrations('axiom-core') end)
+  if not ok then log.error('RunMigrations failed: %s\n%s', tostring(err), debug.traceback()) end
   while running do Wait(hb); log.trace('Heartbeat ok') end
 end)
 


### PR DESCRIPTION
## Summary
- add SQL/parameter guards and detailed logging in db wrappers
- pass typed helpers to migrations and log structured error details
- rewrite migration 0014 to check and create indexes individually
- surface migration failures on startup

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update >/tmp/apt.log` *(fails: The repository is not signed)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d5e6702dc832fa86d244a1e540f05