### PR TITLE
Handle funcref migrations safely

### DIFF
--- a/server/core/migrations.lua
+++ b/server/core/migrations.lua
@@ -78,6 +78,13 @@ local function runFor(mig)
     if not ok then error({ stage = 'sql', sql = mig, params_kind = 'nil', err = tostring(res) }) end
     return
   elseif t == 'table' then
+    local indexable = pcall(function() return mig[1] end)
+    if not indexable then
+      local ctx = makeCtx()
+      local ok, err = pcall(mig, ctx)
+      if not ok then error({ stage = 'fn', sql = nil, params_kind = 'nil', err = tostring(err) }) end
+      return
+    end
     if type(mig.fn) == 'function' then
       runFor(mig.fn)
       return


### PR DESCRIPTION
## Summary
- avoid indexing function references during migrations
- allow function reference steps to run directly

## Testing
- `luac -p server/core/migrations.lua` *(fails: command not found)*
- `apt-get update && apt-get install -y lua5.4` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dfa595178832fb27e6fb68aaa483a