### PR TITLE
fix: ensure index migration and error logging

### DIFF
--- a/server/core/migrations.lua
+++ b/server/core/migrations.lua
@@ -133,19 +133,10 @@ local function runModule(mod)
       if Axiom.audit then Axiom.audit('migration.start', mod..':'..m.version, 'system') end
       local ok, err = pcall(function() runFor(m.steps) end)
       if not ok then
-        local det = err
-        local msg, stage, sqlPrev, paramsKind
-        if type(det) == 'table' then
-          msg        = det.err or det.message or det.code or tostring(det)
-          stage      = det.stage or 'sql'
-          sqlPrev    = preview(det.sql)
-          paramsKind = det.params_kind or 'nil'
-        else
-          msg        = tostring(det)
-          stage      = 'sql'
-          sqlPrev    = preview(nil)
-          paramsKind = 'nil'
-        end
+        local msg = (type(err) == 'table' and (err.err or err.message)) or tostring(err)
+        local stage = (type(err) == 'table' and err.stage) or 'sql'
+        local sqlPrev = (type(err) == 'table' and preview(err.sql)) or preview(nil)
+        local paramsKind = (type(err) == 'table' and err.params_kind) or 'nil'
         log.error('Migration %s:%s FEHLER stage=%s sql_preview="%s" params=%s error=%s\n%s',
           mod, m.version, stage, sqlPrev, paramsKind, msg, debug.traceback())
         if Axiom.audit then Axiom.audit('migration.error', mod..':'..m.version, 'system', tostring(msg)) end

--- a/server/core/migrations_core.lua
+++ b/server/core/migrations_core.lua
@@ -79,18 +79,16 @@ RegisterMigration('axiom-core', '0014_indexes', function(ctx)
     { table = 'ax_player_meta',    index = 'ix_uid', column = 'uid' },
     { table = 'ax_character_meta', index = 'ix_cid', column = 'cid' },
   }
-  ctx.tx(function(tx)
-    for _, ix in ipairs(indexes) do
-      local exists = tx.scalar(
-        'SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name=? AND index_name=?',
-        { ix.table, ix.index }
-      ) or 0
-      if exists == 0 then
-        tx.exec(('ALTER TABLE %s ADD INDEX %s (%s)'):format(ix.table, ix.index, ix.column))
-        log.info('Migration 0014: created index %s on %s(%s)', ix.index, ix.table, ix.column)
-      else
-        log.info('Migration 0014: index %s already present', ix.index)
-      end
+  for _, ix in ipairs(indexes) do
+    local exists = ctx.scalar(
+      'SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name=? AND index_name=?',
+      { ix.table, ix.index }
+    ) or 0
+    if exists == 0 then
+      ctx.exec(('ALTER TABLE %s ADD INDEX %s (%s)'):format(ix.table, ix.index, ix.column))
+      log.info('Migration 0014: created index %s on %s(%s)', ix.index, ix.table, ix.column)
+    else
+      log.info('Migration 0014: index %s already present', ix.index)
     end
-  end)
+  end
 end)


### PR DESCRIPTION
## Summary
- make 0014 index migration idempotent without transactions
- harden migration runner error logging to always emit messages

## Testing
- `luacheck server/core/migrations_core.lua server/core/migrations.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `luac -p server/core/migrations_core.lua server/core/migrations.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dfcdbf314832f915ba12b69c421f9