### PR TITLE
feat: add error taxonomy and connection metrics

### DIFF
--- a/server/core/validator.lua
+++ b/server/core/validator.lua
@@ -1,6 +1,8 @@
 Axiom = Axiom or {}
 Axiom.v = {}
-local err = (Axiom.err and Axiom.err.fail) or function(code,msg,data) return { ok=false, code=code, msg=msg, data=data } end
+local err = (Axiom.err and Axiom.err.fail) or function(code,msg,data)
+  return { ok=false, error={ code=code, message=msg, details=data } }
+end
 
 function Axiom.v.type(val, want) return (type(val) == want), ('expected '..want..', got '..type(val)) end
 function Axiom.v.len(s, min, max) if type(s)~='string' then return false,'expected string' end local n=#s; if min and n<min then return false,'min '..min end if max and n>max then return false,'max '..max end return true end

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -4,10 +4,18 @@ Axiom.config = {
   log_level     = 'info',
   heartbeat_ms  = 60000,
 
-  -- Identifier-Reihenfolge (welcher gespeichert wird)
+  -- Identifier-Policy
   identifiers = {
-    preferred = { 'license', 'steam', 'rockstar', 'fivem', 'discord', 'xbl', 'live', 'ip' },
+    -- Primärer Identifier (Quelle der Wahrheit)
+    primary   = 'license',
+    -- Sekundäre Identifier in deterministischer Reihenfolge
+    secondary = { 'steam', 'rockstar', 'fivem', 'discord', 'xbl', 'live', 'ip' },
     store_kind = true,
+    auto_link = {
+      enabled = true,   -- zusätzliche Identifier beim Connect sammeln
+      shadow  = true,   -- nur loggen, nicht automatisch verknüpfen
+      types   = {},     -- opt-in je Identifier-Typ (z.B. {steam=true})
+    },
   },
 
   -- Maintenance: Admin-Rolle darf rein, plus optional Allowlist


### PR DESCRIPTION
## Summary
- define canonical error codes and expose correlation ids for tracing
- track resolve and ban metrics on player connect
- document identifier primary/secondary policy with optional shadow auto-linking

## Testing
- `apt-get update` *(fails: 403 Forbidden, repository not signed)*
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e2f2d5ef8832fb39dc79ec4a74a61